### PR TITLE
GH-51: Configure CircleCI for Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,31 @@
-# Java Gradle CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-java/ for more details
-#
 version: 2
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/openjdk:8-jdk
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
     working_directory: ~/imhungry
-
+    docker:
+    - image: circleci/android:api-28
     environment:
-      # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
-      TERM: dumb
-
     steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: gradle dependencies
-
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle" }}
-
-      # run tests!
-      - run: gradle test
-workflows:
-  version: 2
-  build_and_test: # < Slack and Email notifications will be delivered for workflows
-    jobs:
-    # All other notification integrations (HipChat, IRC, etc) will receive notification for each job.
-      - build
+    - checkout
+    - restore_cache:
+        key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+    #      - run:
+    #         name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+    #         command: sudo chmod +x ./gradlew
+    - run:
+        name: Download Dependencies
+        command: ./gradlew androidDependencies
+    - save_cache:
+        paths:
+        - ~/.gradle
+        key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+    - run:
+        name: Run Tests
+        command: ./gradlew lint test
+    - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+        path: app/build/reports
+        destination: reports
+    - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+        path: app/build/test-results
+    # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,12 @@ jobs:
     - restore_cache:
         key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
     - run:
+        name: Create Google Services JSON File
+        command: echo $GOOGLE_SERVICES_JSON >> app/google-services.json
+    - run:
+        name: Create Google Maps API XML File
+        command: echo $GOOGLE_MAPS_XML >> app/src/main/res/values/google_maps_api.xml
+    - run:
         name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
         command: sudo chmod +x ./gradlew
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,14 @@ jobs:
     #         command: sudo chmod +x ./gradlew
     - run:
         name: Download Dependencies
-        command: ./gradlew androidDependencies
+        command: gradle androidDependencies
     - save_cache:
         paths:
         - ~/.gradle
         key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
     - run:
         name: Run Tests
-        command: ./gradlew lint test
+        command: gradle lint test
     - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
         path: app/build/reports
         destination: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,19 +10,19 @@ jobs:
     - checkout
     - restore_cache:
         key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-    #      - run:
-    #         name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-    #         command: sudo chmod +x ./gradlew
+    - run:
+        name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+        command: sudo chmod +x ./gradlew
     - run:
         name: Download Dependencies
-        command: gradle androidDependencies
+        command: ./gradlew androidDependencies
     - save_cache:
         paths:
         - ~/.gradle
         key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
     - run:
         name: Run Tests
-        command: gradle lint test
+        command: ./gradlew lint test
     - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
         path: app/build/reports
         destination: reports


### PR DESCRIPTION
This implementation does not build debug or release APKs, but simply builds/runs tests.

Closes #51 
