### PR TITLE
GH-63: Fix CodeCov, add Unit Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ jobs:
         command: ./gradlew lint test
     - run:
         name: Coverage Reports
-        command: ./gradlew jacocoTestReport connectedCheck
+        command: ./gradlew jacocoTestReport
     - run:
         name: Codecov Setup
         command: sudo mv .codecov/codecov.yml .codecov.yml
     - codecov/upload:
-        file: app/build/reports/coverage/debug/report.xml
+        file: app/build/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml
     - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
         path: app/build/reports
         destination: reports

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,8 @@ apply plugin: 'com.google.gms.google-services'
 
 apply plugin: 'jacoco-android'
 
+apply plugin: 'de.mannodermaus.android-junit5'
+
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -43,6 +45,22 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        exclude 'META-INF/*'
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.3"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+jacocoAndroidUnitTestReport {
+    excludes += ['**/di/*',
+                 '**/*Impl*']
 }
 
 dependencies {
@@ -104,6 +122,8 @@ dependencies {
     // Testing
     testImplementation "io.mockk:mockk:1.9"
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.2-alpha01'
+    androidTestImplementation 'androidx.test:runner:1.1.2-alpha02'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0-alpha02'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
 }

--- a/app/src/main/kotlin/io/imhungry/login/LoginUtil.kt
+++ b/app/src/main/kotlin/io/imhungry/login/LoginUtil.kt
@@ -9,7 +9,7 @@ import io.imhungry.login.LoginConstants.RC_SIGN_IN
 import io.imhungry.notifications.NotificationHelper
 import io.imhungry.notifications.NotificationPriority
 
-private object LoginConstants {
+internal object LoginConstants {
     val AUTH_PROVIDERS = listOf(
         AuthUI.IdpConfig.EmailBuilder().build(),
         AuthUI.IdpConfig.GoogleBuilder().build()
@@ -40,13 +40,6 @@ fun Activity.handleLoginActivityResult(
         RC_SIGN_IN -> {
             if (resultCode == Activity.RESULT_OK) {
                 startActivity(Intent(this, HomeActivity::class.java))
-                NotificationHelper(this).sendNotificationNow(
-                    "Welcome!",
-                    "We hope you're hungry!",
-                    null,
-                    NotificationPriority.DEFAULT,
-                    0
-                )
             } else {
                 if (failureCallback != null) {
                     failureCallback()

--- a/app/src/test/kotlin/io/imhungry/login/LoginUtilTest.kt
+++ b/app/src/test/kotlin/io/imhungry/login/LoginUtilTest.kt
@@ -1,0 +1,26 @@
+package io.imhungry.login
+
+import androidx.appcompat.app.AppCompatActivity
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+
+internal class LoginUtilTest {
+
+    @RelaxedMockK
+    private lateinit var mockActivity: AppCompatActivity
+
+    @BeforeEach
+    fun init() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `GIVEN login activity WHEN handle login result THEN verify home launched`() {
+        mockActivity.handleLoginActivityResult(LoginConstants.RC_SIGN_IN, AppCompatActivity.RESULT_OK, null)
+        verify { mockActivity.startActivity(any()) }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.2.0'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.4.0.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Some notes on this PR.

- jacoco/testDebugUnitTest.exec was never getting created therefore tests couldn't be read. To solve this, introducing [Android-JUnit5](https://github.com/mannodermaus/android-junit5) plug in alleviated that issue.
- jacocoTestReport provides multiple reports. Returning the report `app` instead of `debugAndroidTest` then showed us our actual code coverage in jacoco.
  - As a result of this, the circleci report path needed to be changed as well.