### PR TITLE
GH-83: Add Firebase models and repositories

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,9 @@ android {
     packagingOptions {
         exclude 'META-INF/*'
     }
+    lintOptions {
+        lintConfig file("../lint.xml")
+    }
 }
 
 jacoco {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,15 +72,16 @@ coveralls {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha02'
-    implementation 'androidx.core:core-ktx:1.1.0-alpha04'
+    implementation 'androidx.appcompat:appcompat:1.1.0-alpha03'
+    implementation 'androidx.core:core-ktx:1.1.0-alpha05'
 
     // Image Downloading/Caching
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Firebase
-    implementation 'com.google.firebase:firebase-core:16.0.7'
-    implementation 'com.google.firebase:firebase-auth:16.1.0'
+    implementation 'com.google.firebase:firebase-core:16.0.8'
+    implementation 'com.google.firebase:firebase-auth:16.2.0'
+    implementation 'com.google.firebase:firebase-firestore:18.2.0'
 
     // Firebase Auth UI
     implementation 'com.firebaseui:firebase-ui-auth:4.3.1'

--- a/app/src/main/kotlin/io/imhungry/common/di/AppComponent.kt
+++ b/app/src/main/kotlin/io/imhungry/common/di/AppComponent.kt
@@ -5,6 +5,7 @@ import dagger.Component
 import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
 import io.imhungry.MainApplication
+import io.imhungry.firebase.di.FirebaseProviderModule
 import io.imhungry.home.di.HomeModule
 import io.imhungry.maps.di.MapsModule
 import io.imhungry.notifications.di.NotificationModule
@@ -20,7 +21,8 @@ import javax.inject.Singleton
         ViewModelModule::class,
         MapsModule::class,
         HomeModule::class,
-        NotificationModule::class
+        NotificationModule::class,
+        FirebaseProviderModule::class
     ]
 )
 interface AppComponent : AndroidInjector<MainApplication> {

--- a/app/src/main/kotlin/io/imhungry/firebase/di/FirebaseProviderModule.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/di/FirebaseProviderModule.kt
@@ -1,2 +1,12 @@
 package io.imhungry.firebase.di
 
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.Module
+import dagger.Provides
+
+@Module
+class FirebaseProviderModule {
+
+    @Provides
+    fun provideFirebaseFirestore() = FirebaseFirestore.getInstance()
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/di/FirebaseProviderModule.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/di/FirebaseProviderModule.kt
@@ -1,0 +1,2 @@
+package io.imhungry.firebase.di
+

--- a/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebasePlace.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebasePlace.kt
@@ -1,0 +1,9 @@
+package io.imhungry.firebase.model.places
+
+data class FirebasePlace(
+    val placesId: String
+) {
+    companion object {
+        const val FIREBASE_COLLECTION_NAME_PLACES = "places"
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseReview.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseReview.kt
@@ -3,7 +3,7 @@ package io.imhungry.firebase.model.places
 import com.google.firebase.Timestamp
 
 data class FirebaseReview(
-    val author: String,
+    val authorUid: String,
     val comment: String,
     val created: Timestamp,
     val placesId: String,

--- a/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseReview.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseReview.kt
@@ -1,0 +1,15 @@
+package io.imhungry.firebase.model.places
+
+import com.google.firebase.Timestamp
+
+data class FirebaseReview(
+    val author: String,
+    val comment: String,
+    val created: Timestamp,
+    val placesId: String,
+    val rating: Int
+) {
+    companion object {
+        const val FIREBASE_COLLECTION_NAME_REVIEWS = "reviews"
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseVisit.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseVisit.kt
@@ -1,0 +1,15 @@
+package io.imhungry.firebase.model.places
+
+import com.google.firebase.Timestamp
+
+data class FirebaseVisit(
+    val ended: Timestamp,
+    val placesId: String,
+    val started: Timestamp,
+    val leader: String,
+    val users: List<String>
+) {
+    companion object {
+        const val FIREBASE_COLLECTION_NAME_VISITS = "visits"
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseVisit.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/places/FirebaseVisit.kt
@@ -3,11 +3,11 @@ package io.imhungry.firebase.model.places
 import com.google.firebase.Timestamp
 
 data class FirebaseVisit(
-    val ended: Timestamp,
+    val ended: Timestamp?,
     val placesId: String,
-    val started: Timestamp,
-    val leader: String,
-    val users: List<String>
+    val started: Timestamp = Timestamp.now(),
+    val leaderUid: String,
+    val userUids: List<String>
 ) {
     companion object {
         const val FIREBASE_COLLECTION_NAME_VISITS = "visits"

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
@@ -9,8 +9,13 @@ data class FirebaseUser(
     val privacy: FirebasePrivacyConfig = FirebasePrivacyConfig(
         favorites = PUBLIC,
         friendsList = PUBLIC,
-        history = PUBLIC,
-        profile = PUBLIC
+        history = PUBLIC
     ),
-    val profileImage: String?
-)
+    val profileImage: String?,
+    val friends: List<String>?,
+    val favorites: List<String>?
+) {
+    companion object {
+        const val FIREBASE_COLLECTION_NAME_USERS = "users"
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
@@ -1,0 +1,9 @@
+package io.imhungry.firebase.model.user
+
+import io.imhungry.firebase.model.user.privacy.FirebasePrivacyConfig
+
+data class FirebaseUser(
+    val privacy: FirebasePrivacyConfig,
+    val profileImage: String,
+    val username: String
+)

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
@@ -4,7 +4,7 @@ import io.imhungry.firebase.model.user.privacy.FirebasePrivacyConfig
 import io.imhungry.firebase.model.user.privacy.FirebasePrivacyLevel.PUBLIC
 
 data class FirebaseUser(
-    val userId: String,
+    val uid: String,
     val username: String,
     val privacy: FirebasePrivacyConfig = FirebasePrivacyConfig(
         favorites = PUBLIC,

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/FirebaseUser.kt
@@ -1,9 +1,16 @@
 package io.imhungry.firebase.model.user
 
 import io.imhungry.firebase.model.user.privacy.FirebasePrivacyConfig
+import io.imhungry.firebase.model.user.privacy.FirebasePrivacyLevel.PUBLIC
 
 data class FirebaseUser(
-    val privacy: FirebasePrivacyConfig,
-    val profileImage: String,
-    val username: String
+    val userId: String,
+    val username: String,
+    val privacy: FirebasePrivacyConfig = FirebasePrivacyConfig(
+        favorites = PUBLIC,
+        friendsList = PUBLIC,
+        history = PUBLIC,
+        profile = PUBLIC
+    ),
+    val profileImage: String?
 )

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/privacy/FirebasePrivacyConfig.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/privacy/FirebasePrivacyConfig.kt
@@ -1,0 +1,8 @@
+package io.imhungry.firebase.model.user.privacy
+
+data class FirebasePrivacyConfig(
+    val favorites: FirebasePrivacyLevel,
+    val friendsList: FirebasePrivacyLevel,
+    val history: FirebasePrivacyLevel,
+    val profile: FirebasePrivacyLevel
+)

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/privacy/FirebasePrivacyConfig.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/privacy/FirebasePrivacyConfig.kt
@@ -3,6 +3,5 @@ package io.imhungry.firebase.model.user.privacy
 data class FirebasePrivacyConfig(
     val favorites: FirebasePrivacyLevel,
     val friendsList: FirebasePrivacyLevel,
-    val history: FirebasePrivacyLevel,
-    val profile: FirebasePrivacyLevel
+    val history: FirebasePrivacyLevel
 )

--- a/app/src/main/kotlin/io/imhungry/firebase/model/user/privacy/FirebasePrivacyLevel.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/model/user/privacy/FirebasePrivacyLevel.kt
@@ -1,0 +1,7 @@
+package io.imhungry.firebase.model.user.privacy
+
+enum class FirebasePrivacyLevel {
+    PUBLIC,
+    FRIENDS,
+    PRIVATE
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
@@ -4,6 +4,7 @@ import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -13,23 +14,33 @@ abstract class FirebaseBaseCollectionRepository<T : Any>(
     protected val collection: CollectionReference,
     private val klass: KClass<out T>
 ) {
-    protected suspend fun performSingleQuery(task: Task<QuerySnapshot>): T? =
+
+    protected suspend fun <R> performTaskAwait(task: Task<R>): R = Tasks.await(task)
+
+    protected suspend fun performSingleQuery(query: Query): T? =
         withContext(Dispatchers.IO) {
-            val singleResult = Tasks.await(task).firstOrNull()
+            val singleResult = Tasks.await(query.limit(1).get()).firstOrNull()
             singleResult?.toObject(klass.java)
         }
 
-    protected suspend fun performListQuery(task: Task<QuerySnapshot>): List<T> =
+    protected suspend fun performListQuery(query: Query): List<T> =
         withContext(Dispatchers.IO) {
-            val results = Tasks.await(task)
+            val results = Tasks.await(query.get())
             results?.toObjects(klass.java) ?: emptyList()
         }
 
-    protected suspend fun performInsertion(value: T): DocumentReference = withContext(Dispatchers.IO) {
-        Tasks.await(collection.add(value))
-    }
+    protected suspend fun performInsertion(value: T, reference: String? = null): DocumentReference =
+        withContext(Dispatchers.IO) {
+            if (reference != null) {
+                collection.document(reference).also {
+                    Tasks.await(it.set(value))
+                }
+            } else {
+                Tasks.await(collection.add(value))
+            }
+        }
 
-    protected suspend fun performUpdate(documentId: String, field: String, value: Any) {
+    protected suspend fun performFieldUpdate(documentId: String, field: String, value: Any) {
         withContext(Dispatchers.IO) {
             Tasks.await(collection.document(documentId).update(field, value))
         }

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
@@ -3,22 +3,41 @@ package io.imhungry.firebase.repository
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.reflect.KClass
 
-abstract class FirebaseBaseCollectionRepository(
-    protected val collection: CollectionReference
+abstract class FirebaseBaseCollectionRepository<T : Any>(
+    protected val collection: CollectionReference,
+    private val klass: KClass<out T>
 ) {
-    protected suspend inline fun <reified T : Any> performSingleQuery(task: Task<QuerySnapshot>): T? =
+    protected suspend fun performSingleQuery(task: Task<QuerySnapshot>): T? =
         withContext(Dispatchers.IO) {
             val singleResult = Tasks.await(task).firstOrNull()
-            singleResult?.toObject(T::class.java)
+            singleResult?.toObject(klass.java)
         }
 
-    protected suspend inline fun <reified T : Any> performListQuery(task: Task<QuerySnapshot>): List<T> =
+    protected suspend fun performListQuery(task: Task<QuerySnapshot>): List<T> =
         withContext(Dispatchers.IO) {
             val results = Tasks.await(task)
-            results?.toObjects(T::class.java) ?: emptyList()
+            results?.toObjects(klass.java) ?: emptyList()
         }
+
+    protected suspend fun performInsertion(value: T): DocumentReference = withContext(Dispatchers.IO) {
+        Tasks.await(collection.add(value))
+    }
+
+    protected suspend fun performUpdate(documentId: String, field: String, value: Any) {
+        withContext(Dispatchers.IO) {
+            Tasks.await(collection.document(documentId).update(field, value))
+        }
+    }
+
+    protected suspend fun performDeletion(documentId: String) {
+        withContext(Dispatchers.IO) {
+            Tasks.await(collection.document(documentId).delete())
+        }
+    }
 }

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
@@ -2,11 +2,14 @@ package io.imhungry.firebase.repository
 
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-abstract class FirebaseBaseRepository {
+abstract class FirebaseBaseCollectionRepository(
+    protected val collection: CollectionReference
+) {
     protected suspend inline fun <reified T : Any> performSingleQuery(task: Task<QuerySnapshot>): T? =
         withContext(Dispatchers.IO) {
             val singleResult = Tasks.await(task).firstOrNull()

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseBaseCollectionRepository.kt
@@ -1,0 +1,21 @@
+package io.imhungry.firebase.repository
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.QuerySnapshot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+abstract class FirebaseBaseRepository {
+    protected suspend inline fun <reified T : Any> performSingleQuery(task: Task<QuerySnapshot>): T? =
+        withContext(Dispatchers.IO) {
+            val singleResult = Tasks.await(task).firstOrNull()
+            singleResult?.toObject(T::class.java)
+        }
+
+    protected suspend inline fun <reified T : Any> performListQuery(task: Task<QuerySnapshot>): List<T> =
+        withContext(Dispatchers.IO) {
+            val results = Tasks.await(task)
+            results?.toObjects(T::class.java) ?: emptyList()
+        }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebasePlaceRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebasePlaceRepository.kt
@@ -1,2 +1,18 @@
 package io.imhungry.firebase.repository
 
+import com.google.firebase.firestore.FirebaseFirestore
+import io.imhungry.firebase.model.places.FirebasePlace
+import javax.inject.Inject
+
+@Deprecated("This isn't presently used because we get all data from Google places, and additionally we shouldn't allow users to create places.")
+class FirebasePlaceRepository @Inject constructor(
+    db: FirebaseFirestore
+) : FirebaseBaseCollectionRepository(db.collection(FirebasePlace.FIREBASE_COLLECTION_NAME_PLACES)) {
+
+    suspend fun getPlace(placesId: String) = performSingleQuery<FirebasePlace>(
+        collection.whereEqualTo(
+            FirebasePlace::placesId.name,
+            placesId
+        ).get()
+    )
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebasePlaceRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebasePlaceRepository.kt
@@ -1,0 +1,2 @@
+package io.imhungry.firebase.repository
+

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebasePlaceRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebasePlaceRepository.kt
@@ -7,12 +7,15 @@ import javax.inject.Inject
 @Deprecated("This isn't presently used because we get all data from Google places, and additionally we shouldn't allow users to create places.")
 class FirebasePlaceRepository @Inject constructor(
     db: FirebaseFirestore
-) : FirebaseBaseCollectionRepository(db.collection(FirebasePlace.FIREBASE_COLLECTION_NAME_PLACES)) {
+) : FirebaseBaseCollectionRepository<FirebasePlace>(
+    db.collection(FirebasePlace.FIREBASE_COLLECTION_NAME_PLACES),
+    FirebasePlace::class
+) {
 
-    suspend fun getPlace(placesId: String) = performSingleQuery<FirebasePlace>(
+    suspend fun getPlace(placesId: String) = performSingleQuery(
         collection.whereEqualTo(
             FirebasePlace::placesId.name,
             placesId
-        ).get()
+        )
     )
 }

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
@@ -1,2 +1,30 @@
 package io.imhungry.firebase.repository
 
+import com.google.firebase.firestore.FirebaseFirestore
+import io.imhungry.firebase.model.places.FirebaseReview
+import javax.inject.Inject
+
+class FirebaseReviewRepository @Inject constructor(
+    db: FirebaseFirestore
+) : FirebaseBaseCollectionRepository(db.collection(FirebaseReview.FIREBASE_COLLECTION_NAME_REVIEWS)) {
+
+    suspend fun getPlaceReviews(placesId: String, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT) =
+        performListQuery<FirebaseReview>(
+            collection.whereEqualTo(
+                FirebaseReview::placesId.name,
+                placesId
+            ).limit(limit).get()
+        )
+
+    suspend fun getUserReviews(userId: String, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT) =
+        performListQuery<FirebaseReview>(
+            collection.whereEqualTo(
+                FirebaseReview::author.name,
+                userId
+            ).limit(limit).get()
+        )
+
+    companion object {
+        const val FIREBASE_REVIEW_DEFAULT_LIMIT = 5L
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
@@ -7,10 +7,13 @@ import javax.inject.Inject
 
 class FirebaseReviewRepository @Inject constructor(
     db: FirebaseFirestore
-) : FirebaseBaseCollectionRepository(db.collection(FirebaseReview.FIREBASE_COLLECTION_NAME_REVIEWS)) {
+) : FirebaseBaseCollectionRepository<FirebaseReview>(
+    db.collection(FirebaseReview.FIREBASE_COLLECTION_NAME_REVIEWS),
+    FirebaseReview::class
+) {
 
     private suspend fun queryReviews(field: String, value: String, limit: Long, startAt: Long) =
-        performListQuery<FirebaseReview>(
+        performListQuery(
             collection.whereEqualTo(
                 field,
                 value
@@ -21,7 +24,11 @@ class FirebaseReviewRepository @Inject constructor(
         queryReviews(FirebaseReview::placesId.name, placesId, limit, startAt)
 
     suspend fun getUserReviews(user: FirebaseUser, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT, startAt: Long = 0) =
-        queryReviews(FirebaseReview::author.name, user.userId, limit, startAt)
+        queryReviews(FirebaseReview::authorUid.name, user.uid, limit, startAt)
+
+    suspend fun addReview(review: FirebaseReview) = performInsertion(review)
+
+    suspend fun deleteReview(reviewId: String) = performDeletion(reviewId)
 
     companion object {
         const val FIREBASE_REVIEW_DEFAULT_LIMIT = 5L

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
@@ -1,0 +1,2 @@
+package io.imhungry.firebase.repository
+

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
@@ -2,27 +2,26 @@ package io.imhungry.firebase.repository
 
 import com.google.firebase.firestore.FirebaseFirestore
 import io.imhungry.firebase.model.places.FirebaseReview
+import io.imhungry.firebase.model.user.FirebaseUser
 import javax.inject.Inject
 
 class FirebaseReviewRepository @Inject constructor(
     db: FirebaseFirestore
 ) : FirebaseBaseCollectionRepository(db.collection(FirebaseReview.FIREBASE_COLLECTION_NAME_REVIEWS)) {
 
-    suspend fun getPlaceReviews(placesId: String, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT) =
+    private suspend fun queryReviews(field: String, value: String, limit: Long, startAt: Long) =
         performListQuery<FirebaseReview>(
             collection.whereEqualTo(
-                FirebaseReview::placesId.name,
-                placesId
-            ).limit(limit).get()
+                field,
+                value
+            ).limit(limit).startAt(startAt).get()
         )
 
-    suspend fun getUserReviews(userId: String, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT) =
-        performListQuery<FirebaseReview>(
-            collection.whereEqualTo(
-                FirebaseReview::author.name,
-                userId
-            ).limit(limit).get()
-        )
+    suspend fun getPlaceReviews(placesId: String, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT, startAt: Long = 0) =
+        queryReviews(FirebaseReview::placesId.name, placesId, limit, startAt)
+
+    suspend fun getUserReviews(user: FirebaseUser, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT, startAt: Long = 0) =
+        queryReviews(FirebaseReview::author.name, user.userId, limit, startAt)
 
     companion object {
         const val FIREBASE_REVIEW_DEFAULT_LIMIT = 5L

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseReviewRepository.kt
@@ -17,7 +17,7 @@ class FirebaseReviewRepository @Inject constructor(
             collection.whereEqualTo(
                 field,
                 value
-            ).limit(limit).startAt(startAt).get()
+            ).limit(limit).startAt(startAt)
         )
 
     suspend fun getPlaceReviews(placesId: String, limit: Long = FIREBASE_REVIEW_DEFAULT_LIMIT, startAt: Long = 0) =

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseUserRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseUserRepository.kt
@@ -1,0 +1,31 @@
+package io.imhungry.firebase.repository
+
+import com.google.firebase.firestore.FirebaseFirestore
+import io.imhungry.firebase.model.user.FirebaseUser
+import io.imhungry.firebase.model.user.privacy.FirebasePrivacyConfig
+import javax.inject.Inject
+
+class FirebaseUserRepository @Inject constructor(
+    db: FirebaseFirestore
+) : FirebaseBaseCollectionRepository<FirebaseUser>(
+    db.collection(FirebaseUser.FIREBASE_COLLECTION_NAME_USERS),
+    FirebaseUser::class
+) {
+
+    suspend fun addUser(user: FirebaseUser) = performInsertion(user, user.uid)
+
+    suspend fun getUser(uid: String) = performSingleQuery(collection.whereEqualTo(FirebaseUser::uid.name, uid))
+
+    suspend fun updateProfileImage(uid: String, imageData: String) =
+        performFieldUpdate(uid, FirebaseUser::profileImage.name, imageData)
+
+    suspend fun updateUsername(uid: String, username: String) =
+        performFieldUpdate(uid, FirebaseUser::username.name, username)
+
+    suspend fun updatePrivacy(uid: String, privacy: FirebasePrivacyConfig) =
+        performFieldUpdate(uid, FirebaseUser::privacy.name, privacy)
+
+    companion object {
+        const val FIREBASE_USER_DEFAULT_LIMIT = 5L
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
@@ -1,2 +1,22 @@
 package io.imhungry.firebase.repository
 
+import com.google.firebase.firestore.FirebaseFirestore
+import io.imhungry.firebase.model.places.FirebaseVisit
+import javax.inject.Inject
+
+class FirebaseVisitRepository @Inject constructor(
+    db: FirebaseFirestore
+) : FirebaseBaseCollectionRepository(db.collection(FirebaseVisit.FIREBASE_COLLECTION_NAME_VISITS)) {
+
+    suspend fun getPlaceVisits(placesId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT) =
+        performListQuery<FirebaseVisit>(
+            collection.whereEqualTo(
+                FirebaseVisit::placesId.name,
+                placesId
+            ).limit(limit).get()
+        )
+
+    companion object {
+        const val FIREBASE_VISIT_DEFAULT_LIMIT = 10L
+    }
+}

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
@@ -17,7 +17,7 @@ class FirebaseVisitRepository @Inject constructor(
             collection.whereEqualTo(
                 field,
                 value
-            ).limit(limit).startAt(startAt).get()
+            ).limit(limit).startAt(startAt)
         )
 
     suspend fun getPlaceVisits(placesId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT, startAt: Long = 0) =
@@ -31,12 +31,12 @@ class FirebaseVisitRepository @Inject constructor(
             collection.whereArrayContains(
                 FirebaseVisit::userUids.name,
                 userId
-            ).limit(limit).startAt(startAt).get()
+            ).limit(limit).startAt(startAt)
         )
 
     suspend fun startVisit(visit: FirebaseVisit) = performInsertion(visit)
 
-    suspend fun endVisit(visitId: String) = performUpdate(visitId, FirebaseVisit::ended.name, Timestamp.now())
+    suspend fun endVisit(visitId: String) = performFieldUpdate(visitId, FirebaseVisit::ended.name, Timestamp.now())
 
     companion object {
         const val FIREBASE_VISIT_DEFAULT_LIMIT = 10L

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
@@ -8,12 +8,26 @@ class FirebaseVisitRepository @Inject constructor(
     db: FirebaseFirestore
 ) : FirebaseBaseCollectionRepository(db.collection(FirebaseVisit.FIREBASE_COLLECTION_NAME_VISITS)) {
 
-    suspend fun getPlaceVisits(placesId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT) =
+    private suspend fun queryVisits(field: String, value: String, limit: Long, startAt: Long) =
         performListQuery<FirebaseVisit>(
             collection.whereEqualTo(
-                FirebaseVisit::placesId.name,
-                placesId
-            ).limit(limit).get()
+                field,
+                value
+            ).limit(limit).startAt(startAt).get()
+        )
+
+    suspend fun getPlaceVisits(placesId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT, startAt: Long = 0) =
+        queryVisits(FirebaseVisit::placesId.name, placesId, limit, startAt)
+
+    suspend fun getLeaderVisits(userId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT, startAt: Long = 0) =
+        queryVisits(FirebaseVisit::leader.name, userId, limit, startAt)
+
+    suspend fun getUserVisits(userId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT, startAt: Long = 0) =
+        performListQuery<FirebaseVisit>(
+            collection.whereArrayContains(
+                FirebaseVisit::users.name,
+                userId
+            ).limit(limit).startAt(startAt).get()
         )
 
     companion object {

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
@@ -1,0 +1,2 @@
+package io.imhungry.firebase.repository
+

--- a/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
+++ b/app/src/main/kotlin/io/imhungry/firebase/repository/FirebaseVisitRepository.kt
@@ -1,15 +1,19 @@
 package io.imhungry.firebase.repository
 
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import io.imhungry.firebase.model.places.FirebaseVisit
 import javax.inject.Inject
 
 class FirebaseVisitRepository @Inject constructor(
     db: FirebaseFirestore
-) : FirebaseBaseCollectionRepository(db.collection(FirebaseVisit.FIREBASE_COLLECTION_NAME_VISITS)) {
+) : FirebaseBaseCollectionRepository<FirebaseVisit>(
+    db.collection(FirebaseVisit.FIREBASE_COLLECTION_NAME_VISITS),
+    FirebaseVisit::class
+) {
 
     private suspend fun queryVisits(field: String, value: String, limit: Long, startAt: Long) =
-        performListQuery<FirebaseVisit>(
+        performListQuery(
             collection.whereEqualTo(
                 field,
                 value
@@ -20,15 +24,19 @@ class FirebaseVisitRepository @Inject constructor(
         queryVisits(FirebaseVisit::placesId.name, placesId, limit, startAt)
 
     suspend fun getLeaderVisits(userId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT, startAt: Long = 0) =
-        queryVisits(FirebaseVisit::leader.name, userId, limit, startAt)
+        queryVisits(FirebaseVisit::leaderUid.name, userId, limit, startAt)
 
     suspend fun getUserVisits(userId: String, limit: Long = FIREBASE_VISIT_DEFAULT_LIMIT, startAt: Long = 0) =
-        performListQuery<FirebaseVisit>(
+        performListQuery(
             collection.whereArrayContains(
-                FirebaseVisit::users.name,
+                FirebaseVisit::userUids.name,
                 userId
             ).limit(limit).startAt(startAt).get()
         )
+
+    suspend fun startVisit(visit: FirebaseVisit) = performInsertion(visit)
+
+    suspend fun endVisit(visitId: String) = performUpdate(visitId, FirebaseVisit::ended.name, Timestamp.now())
 
     companion object {
         const val FIREBASE_VISIT_DEFAULT_LIMIT = 10L

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,5 @@
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="**/grpc*.jar"/>
+    </issue>
+</lint>


### PR DESCRIPTION
This is the first PR of many in regards to changes with Firebase. I am merging in stages as to keep the PRs down to a manageable size.

This adds the first stage, the lowest-level models used directly in Firebase, along with repositories for accessing them. In the future, this will be abstracted through a couple layers, allowing for far easier usage with the Places API and Firebase as one.